### PR TITLE
fix: Remove workflow schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ on:
   pull_request:
     branches:
       - "*"
-  schedule:
-    - cron: "0 7 1 * *"
 
 jobs:
   test:


### PR DESCRIPTION
GitHub unfortunately disables workflows with a schedule on any repo without activity for 60 days. This disabling is silent and invisible, only showing up as a slightly different icon next to the job on the Actions page. Clicking that icon will prompt whether you want to re-enable it. But at that point the damage is already done, in shape of a lot of fiddling to figure out what went wrong, and having to re-push PRs with different contents to actually trigger the now active workflow.

There's been no response from GitHub about this issue yet <https://github.com/orgs/community/discussions/32197>.

This is part of fixing
<https://github.com/linz/ds-infra-team/issues/927>.